### PR TITLE
fix: リポジトリ一覧をきれいにする

### DIFF
--- a/lib/components/repository_info_tile.dart
+++ b/lib/components/repository_info_tile.dart
@@ -1,6 +1,16 @@
 import 'package:flutter/material.dart';
 
 class RepositoryInfoTile extends StatelessWidget {
+  /// リポジトリ検索結果画面に表示するリポジトリ情報を表示するタイル
+  ///
+  /// [imagePath] 画像のURL.円形に切り取られ、背景が投下されている場合は[Colors.white]で表示される.
+  ///
+  /// [name] リポジトリ名として表示される.
+  ///
+  /// [description] リポジトリの説明文として表示される.
+  ///
+  /// [onPressed] タップ時のコールバック関数.指定されていない場合は右端に矢印アイコンが表示されない.
+
   const RepositoryInfoTile({
     required this.imagePath,
     required this.name,
@@ -20,16 +30,13 @@ class RepositoryInfoTile extends StatelessWidget {
       onTap: onPressed,
       child: Container(
         width: double.infinity,
-        height: 64,
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          border: Border.all(),
-          borderRadius: BorderRadius.circular(4),
-        ),
+        height: 80,
+        padding: const EdgeInsets.all(16),
         child: Row(
           children: [
             CircleAvatar(
               backgroundImage: NetworkImage(imagePath),
+              backgroundColor: Colors.white,
             ),
             const SizedBox(width: 8),
             Expanded(
@@ -56,6 +63,11 @@ class RepositoryInfoTile extends StatelessWidget {
               ),
             ),
             const SizedBox(width: 8),
+            if (onPressed != null)
+              const Icon(
+                Icons.chevron_right,
+                size: 28,
+              ),
           ],
         ),
       ),

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -56,24 +56,21 @@ class SearchPage extends ConsumerWidget {
                 child: PagedListView.separated(
                   pagingController: controller.pagingController,
                   separatorBuilder: (context, index) =>
-                      const SizedBox(height: 8),
+                      const Divider(height: 1),
                   builderDelegate: PagedChildBuilderDelegate(
                     itemBuilder: (context, item, index) {
                       final repositoryInfo = item as RepositoryInfo;
-                      return Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8.0),
-                        child: RepositoryInfoTile(
-                          imagePath: repositoryInfo.ownerIconPath,
-                          name: repositoryInfo.fullName,
-                          description: repositoryInfo.description ?? '',
-                          onPressed: () {
-                            context.push(
-                              '/detail',
-                              extra: repositoryInfo,
-                            );
-                            controller.pagingController.value.status;
-                          },
-                        ),
+                      return RepositoryInfoTile(
+                        imagePath: repositoryInfo.ownerIconPath,
+                        name: repositoryInfo.fullName,
+                        description: repositoryInfo.description ?? '',
+                        onPressed: () {
+                          context.push(
+                            '/detail',
+                            extra: repositoryInfo,
+                          );
+                          controller.pagingController.value.status;
+                        },
                       );
                     },
                     // 初回読み込み時にエラーが発生した場合このbuilderが呼ばれる


### PR DESCRIPTION
# 概要
- #16 
- 検索結果画面のタイルをきれいなデザインにする
- componentにコメントを追加する


## スクリーンショット
<!-- UIの変更を行った場合に添付する -->
![Simulator Screenshot - iPhone 15 - 2024-05-06 at 07 43 07](https://github.com/you22fy/yumemi_flutter/assets/93398385/e1a17d03-ae35-4fa4-9e2c-bce45196adca)

## 懸念点
<!-- 実装に懸念点があれば記載する -->

## セルフチェック

- [ ] `flutter analyze`で問題がない
- [ ] `flutter test`で問題がない
- [x] 実機またはエミュレータで動作確認を行った
- [x] UI変更があればスクリーンショットを添付した
