### PR TITLE
ダークモードの実装とテーマの切り替え

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter/router.dart';
 
+import 'providers/theme_mode_provider.dart';
+
 void main() {
   runApp(
     const ProviderScope(
@@ -10,20 +12,21 @@ void main() {
   );
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final themeMode = ref.watch(themeModeProvider);
+
     return MaterialApp.router(
       routerDelegate: goRouter.routerDelegate,
       routeInformationParser: goRouter.routeInformationParser,
       routeInformationProvider: goRouter.routeInformationProvider,
       title: 'Flutter Demo',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
-        useMaterial3: true,
-      ),
+      theme: ThemeData.light(),
+      darkTheme: ThemeData.dark(),
+      themeMode: themeMode,
     );
   }
 }

--- a/lib/pages/detail/detail_page.dart
+++ b/lib/pages/detail/detail_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:yumemi_flutter/components/components.dart';
 import 'package:yumemi_flutter/models/repository_info.dart';
+import 'package:yumemi_flutter/providers/theme_mode_provider.dart';
 
 /// 各リポジトリの詳細情報を表示するページ
 /// リポジトリ名、オーナーアイコン、プロジェクト言語、Star数、Watcher数、Fork数、Issue数を表示する
@@ -20,6 +21,16 @@ class DetailPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: Text(repositoryInfo.fullName),
+        actions: [
+          IconButton(
+            onPressed: () {
+              ref.read(themeModeProvider.notifier).toggleTheme();
+            },
+            icon: ref.watch(themeModeProvider) == ThemeMode.light
+                ? const Icon(Icons.dark_mode_outlined)
+                : const Icon(Icons.light_mode),
+          ),
+        ],
       ),
       body: SizedBox(
         width: double.infinity,

--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 import 'package:yumemi_flutter/models/repository_info.dart';
 import 'package:yumemi_flutter/pages/search/search_page_controller.dart';
+import 'package:yumemi_flutter/providers/theme_mode_provider.dart';
 import '../../components/components.dart';
 
 /// アプリのトップページになるウィジェット
@@ -19,6 +20,16 @@ class SearchPage extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Search Page'),
+        actions: [
+          IconButton(
+            onPressed: () {
+              ref.read(themeModeProvider.notifier).toggleTheme();
+            },
+            icon: ref.watch(themeModeProvider) == ThemeMode.light
+                ? const Icon(Icons.dark_mode_outlined)
+                : const Icon(Icons.light_mode),
+          ),
+        ],
       ),
       body: GestureDetector(
         onTap: () => FocusScope.of(context).unfocus(),

--- a/lib/providers/theme_mode_provider.dart
+++ b/lib/providers/theme_mode_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final themeModeProvider = StateNotifierProvider<ThemeModeProvider, ThemeMode>(
+  (ref) => ThemeModeProvider(),
+);
+
+class ThemeModeProvider extends StateNotifier<ThemeMode> {
+  ThemeModeProvider() : super(ThemeMode.light);
+
+  void toggleTheme() {
+    state = state == ThemeMode.light ? ThemeMode.dark : ThemeMode.light;
+  }
+}


### PR DESCRIPTION
# 概要
#8 
- ダークモードに対応する
- ダークモードとライトモードの切り替えができるようになる。

## スクリーンショット

| ライトモード | ダークモード |
| --- | --- |
| ![Simulator Screenshot - iPhone 15 - 2024-05-06 at 07 01 19](https://github.com/you22fy/yumemi_flutter/assets/93398385/e4a69d91-39a3-4816-9115-cab0960b925d) |  ![Simulator Screenshot - iPhone 15 - 2024-05-06 at 08 20 02](https://github.com/you22fy/yumemi_flutter/assets/93398385/81da8b46-e3de-4c71-9e05-3460890404e1) | 


## 懸念点
<!-- 実装に懸念点があれば記載する -->
providerの持ち方

## セルフチェック

- [ ] `flutter analyze`で問題がない
- [ ] `flutter test`で問題がない
- [ ] 実機またはエミュレータで動作確認を行った
- [ ] UI変更があればスクリーンショットを添付した
