### PR TITLE
ページ上部に戻るための動線の実装

### DIFF
--- a/lib/pages/search/search_page.dart
+++ b/lib/pages/search/search_page.dart
@@ -53,6 +53,7 @@ class SearchPage extends ConsumerWidget {
               },
               child: PagedListView.separated(
                 pagingController: controller.pagingController,
+                scrollController: notifier.scrollController,
                 separatorBuilder: (context, index) => const Divider(height: 1),
                 builderDelegate: PagedChildBuilderDelegate(
                   itemBuilder: (context, item, index) {
@@ -87,6 +88,16 @@ class SearchPage extends ConsumerWidget {
             ),
           ),
         ],
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          notifier.scrollController.animateTo(
+            0,
+            duration: const Duration(milliseconds: 300),
+            curve: Curves.easeInOut,
+          );
+        },
+        child: const Icon(Icons.arrow_upward),
       ),
     );
   }

--- a/lib/pages/search/search_page_controller.dart
+++ b/lib/pages/search/search_page_controller.dart
@@ -17,6 +17,7 @@ class SearchPageController extends StateNotifier<SearchPageState> {
   final GithubRepository githubRepository;
 
   TextEditingController textEditingController = TextEditingController();
+  ScrollController scrollController = ScrollController();
 
   SearchPageController(this.githubRepository)
       : super(SearchPageState.initial()) {


### PR DESCRIPTION
# 概要
- 検索結果画面の最上部に戻れるようにする
## スクリーンショット
![Simulator Screenshot - iPhone 15 - 2024-05-07 at 20 08 50](https://github.com/you22fy/yumemi_flutter/assets/93398385/3a006fdd-1aa1-4cfc-b640-136286a617a9)


## 懸念点

<!-- 実装に懸念点があれば記載する -->

## セルフチェック

- [x] `flutter analyze`で問題がない
- [ ] `flutter test`で問題がない
- [ ] 実機またはエミュレータで動作確認を行った
- [ ] UI変更があればスクリーンショットを添付した
